### PR TITLE
Add option for CSP nonce

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ class CSVBoxImporter {
 
             let css = document.createElement("style");
             css.type = "text/css";
+
+            if (!!configuration.nonce) {
+                css.nonce = configuration.nonce;
+            }
+
             if ("textContent" in css)
                 css.textContent = cssText;
             else


### PR DESCRIPTION
Adds an option for a user provided nonce to support a more secure content security policy. Otherwise it's impossible to use this plugin with a strict CSP.